### PR TITLE
Fix Logging of Error objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/logger",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Invisible Logging Wrapper",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bugsnag": "^1.12.0",
     "glob": "^7.1.2",
     "moment": "^2.18.1",
-    "winston": "^2.3.1",
+    "winston": "2.3.0",
     "winston-bugsnag": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,17 @@ winston-bugsnag@^3.0.0:
     bugsnag "^1.11.0"
     winston "^2.3.1"
 
+winston@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.3.0.tgz#207faaab6fccf3fe493743dd2b03dbafc7ceb78c"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
+
 winston@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.3.1.tgz#0b48420d978c01804cf0230b648861598225a119"


### PR DESCRIPTION
My guess is that Winston folks rather focus on v3 that is on RC right now.