### PR TITLE
Fix: infer release version from package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# Each project can have an ignore subdirectory
+ignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/logger",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Invisible Logging Wrapper",
   "main": "index.js",
   "scripts": {

--- a/transports/bugsnag.js
+++ b/transports/bugsnag.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const bugsnag = require('bugsnag')
 const { BugsnagTransport } = require('winston-bugsnag')
 
@@ -15,7 +16,8 @@ assertLevel(BUGSNAG_LEVEL, 'BUGSNAG_LEVEL invalid.')
 let transport
 if (BUGSNAG_KEY) {
   const projectRoot = process.cwd()
-  bugsnag.register(BUGSNAG_KEY, { projectRoot })
+  const packageJSON = path.join(projectRoot, 'package.json')
+  bugsnag.register(BUGSNAG_KEY, { projectRoot, packageJSON })
 
   transport = new BugsnagTransport({
     name: 'bugsnag',


### PR DESCRIPTION
## Description

Solves -> https://trello.com/c/An6bloMr/751-bugsnag-release-unknown

Changes because of the code on: 
- https://github.com/bugsnag/bugsnag-node/blob/master/lib/configuration.js#L71
- https://github.com/bugsnag/bugsnag-node/blob/master/lib/utils.js#L30

## Test Plan
Run the following script with the test project API from Bugsnag -> https://app.bugsnag.com/settings/invisible/projects/test

```
'use strict'

process.env.NODE_ENV = 'development'
process.env.BUGSNAG_KEY = '<INSERT-YOUR-API-KEY-HEREEE!!!>'
const logger = require('@invisible/logger')

logger.warn('Testing release metadata')
```

Verify that an event is created with release version on:
https://app.bugsnag.com/invisible/test/errors?filters[event.since][0]=30d&filters[error.status][0]=open

Make the same change inside `node_modules` of any project and add Test `BUGSNAG_KEY` to your `.env`. It should work as expected too.

----
I will probably send a PR "fixing" this on -> https://github.com/bugsnag/bugsnag-node/

I will add another fix on the PR for this for consistency with their `js` module -> `bugsnag.register('API_KEY') === bugsnag.register({ apiKey: 'API_KEY' })`
Reference: https://github.com/bugsnag/bugsnag-node/blob/master/lib/bugsnag.js#L118
