### PR TITLE
Fix: log Errors on winston ^2.3.1

### DIFF
--- a/helpers/cloneErrorProxy.js
+++ b/helpers/cloneErrorProxy.js
@@ -11,7 +11,7 @@ const LOGGING_LEVELS = [
   'silly',
 ]
 
-// FIX: because winston from versions 2.3.1 until 2.4.0 does not log Error objects.
+// FIX: because winston from versions 2.3.1 until 2.4.0 do not log Error objects.
 const cloneErrorProxy = logger => {
   const handler = {
     get: (target, name) => {

--- a/helpers/cloneErrorProxy.js
+++ b/helpers/cloneErrorProxy.js
@@ -1,5 +1,7 @@
 'use strict'
 
+// I copied LOGGING_LEVELS from src/helpers/assertLevel.js
+// because this file is going to be deprecated when the bug is solved on winston.
 const LOGGING_LEVELS = [
   'error',
   'warn',
@@ -9,7 +11,7 @@ const LOGGING_LEVELS = [
   'silly',
 ]
 
-// FIX: winston from 2.3.1 until 2.4.0 doesn't log Error objects.
+// FIX: because winston from versions 2.3.1 until 2.4.0 does not log Error objects.
 const cloneErrorProxy = logger => {
   const handler = {
     get: (target, name) => {

--- a/helpers/cloneErrorProxy.js
+++ b/helpers/cloneErrorProxy.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const LOGGING_LEVELS = [
+  'error',
+  'warn',
+  'info',
+  'verbose',
+  'debug',
+  'silly',
+]
+
+// FIX: winston from 2.3.1 until 2.4.0 doesn't log Error objects.
+const cloneErrorProxy = logger => {
+  const handler = {
+    get: (target, name) => {
+      // If the target[name] is a logging level we should verify if any
+      // of the arguments is an Error.
+      if (LOGGING_LEVELS.indexOf(name) > -1) {
+        return (...loggerArgs) => {
+          const validArgs = loggerArgs
+            .map(loggerArg => {
+              if (loggerArg instanceof Error) {
+                // Loosely "Clone" Error Objects
+                return {
+                  message: loggerArg.message,
+                  stack: loggerArg.stack,
+                }
+              }
+              return loggerArg
+            })
+
+          return target[name](...validArgs)
+        }
+      }
+
+      return target[name]
+    },
+  }
+
+  return new Proxy(logger, handler)
+}
+
+module.exports = cloneErrorProxy

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const unwrappedLogger = new (winston.Logger)({
 })
 
 // We are proxying winston logger because versions from 2.3.0 until 2.4.0
-// does not log Error objects. The proxy is going to be DEPRECATED
+// do not log Error objects. The proxy is going to be DEPRECATED
 // after winston solves its bug.
 const logger = cloneErrorProxy(unwrappedLogger)
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const unwrappedLogger = new (winston.Logger)({
   transports,
 })
 
+// We are proxying winston logger because versions from 2.3.0 until 2.4.0
+// does not log Error objects. The proxy is going to be DEPRECATED
+// after winston solves its bug.
 const logger = cloneErrorProxy(unwrappedLogger)
 
 module.exports = logger

--- a/index.js
+++ b/index.js
@@ -3,13 +3,17 @@
 const glob = require('glob')
 const winston = require('winston')
 
+const cloneErrorProxy = require('./helpers/cloneErrorProxy')
+
 const isTransport = t => t && t.log
 const transports = glob.sync('./transports/*.js', { cwd: __dirname })
   .map(require)
   .filter(isTransport)
 
-const logger = new (winston.Logger)({
+const unwrappedLogger = new (winston.Logger)({
   transports,
 })
+
+const logger = cloneErrorProxy(unwrappedLogger)
 
 module.exports = logger

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/logger",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Invisible Logging Wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
This PR fixes the issue https://github.com/winstonjs/winston/issues/1178 from `winston` using a proxy on our logger.

## Test plan
1. Create a temporary package dir (`mkdir /tmp/x;cd /tmp/x;npm init --yes`)
2. Add logger (`yarn add invisible-tech/logger#rgo/fix-winston`)
3. Create `repro.js` with `const logger = require('@invisible/logger');logger.error(Error('Errors can be cool'))`
4. Run `node repro.js`

The output is an error object "equals" to the one returned on `winston@2.3.0`.
It is not only the error message as on the card: https://trello.com/c/9p0K6DFe/776-logging-error-objects