### PR TITLE
Fix Timber for Error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+*v2.1.0*
+> Internal: Serialize error objects
+
 *v2.0.0*
 > Internal: Remove unused Loggly and Bugsnag
 > Internal: Remove unecessary patch

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@invisible/changelog-update": "^1.1.0",
     "moment": "^2.18.1",
+    "serialize-error": "^2.1.0",
     "timber": "^3.1.1",
     "winston": "^2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/logger",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Invisible Logging Wrapper",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@invisible/changelog-update": "^1.1.0",
     "moment": "^2.18.1",
-    "postinstall-prepare": "^1.0.1",
     "timber": "^3.1.1",
     "winston": "^2.4.0"
   },

--- a/transports/timber.js
+++ b/transports/timber.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const winston = require('winston')
+const serializeError = require('serialize-error')
 const timber = require('timber')
+
 const assertLevel = require('./helpers/assertLevel')
 
 const {
@@ -22,7 +24,10 @@ module.exports = new (winston.transports.Console)({
   formatter: options => {
     // When we log errors, options.message comes as blank and it causes errors
     const message = options.message || options.meta.message || 'No message'
-    const formatted = timber.formatters.Winston({ ...options, message })
+    // Serialize eventual error objecs
+    // https://github.com/timberio/timber-node/issues/87
+    const sanitized = serializeError(options)
+    const formatted = timber.formatters.Winston({ ...sanitized, message })
     return dropLineBreak(formatted)
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,6 +1931,10 @@ semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
+serialize-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,10 +1714,6 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-postinstall-prepare@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/postinstall-prepare/-/postinstall-prepare-1.0.1.tgz#dac9b5d91b054389141b13c0192eb68a0aa002b5"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
I hope this finally does it.
If we used Lerna I could've done it all in one PR.
Now I've got to merge this first, then experiment on postman staging.

Not even patch-package was able to help me this time.
I tried to run experiments on staging based on patch-package but it seems it
has a problem with named packages (e.g. *@invisible/*logger).

![image](https://user-images.githubusercontent.com/7684574/46057368-b937da80-c12b-11e8-85e6-d29cb123d7cf.png)
